### PR TITLE
remove trailing comma (fix for node v6.x)

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -184,7 +184,7 @@ function processSourceMap(sys, config){
 function getCachedFilepath(filepath){
   return path.join(
     permaCache.path,
-    filepath.replace(permaCache.cwd, ''),
+    filepath.replace(permaCache.cwd, '')
   );
 }
 


### PR DESCRIPTION
I want to use this library with Node v6.11.3(the LTS version).
On Node v6.x, trailing commas in function parameter lists  are not allowed(c.f. http://node.green/#ES2017-features-trailing-commas-in-function-syntax).
Could you merge this PR?